### PR TITLE
add support for P values with precision that would underflow a float

### DIFF
--- a/pvalueHandler.py
+++ b/pvalueHandler.py
@@ -1,0 +1,38 @@
+import decimal
+
+class PvalueHandler:
+
+    def __init__(self):
+        # initialize decimal math
+        decimal.setcontext(decimal.BasicContext)
+        decimal.getcontext().prec = 9
+        decimal.getcontext().Emin = -10000000
+        decimal.getcontext().Emax = 10000000
+        # values to remember
+        self.minimum_value_str = "0"
+        self.maximum_value_str = "1"
+        self.minimum_value = decimal.Decimal(self.minimum_value_str)
+        self.maximum_value = decimal.Decimal(self.maximum_value_str)
+        self.field_name = "p-values"
+
+    # returns a decimal representation of the input string, or else raises an exception
+    def parse_string (self,value_as_string):
+        d = decimal.Decimal(value_as_string)
+        if d.is_nan():
+            raise Exception (f"Unable to convert '{value_as_string}' to a decimal value")
+        if d <= self.minimum_value:
+            raise Exception (f"Error: {self.field_name} must be greater than {self.minimum_value_str}")
+        if d > self.maximum_value:
+            raise Exception(f"Error: {self.field_name} can not be greater than {self.maximum_value_str}")
+        return d
+
+    # returns a float representation of the negative log of the input decimal, or raises an exception
+    def neg_log_of_decimal (self,p_value):
+        # prevent negative 0 output
+        if p_value == self.maximum_value:
+            return 0
+        # prevent Inf output
+        if p_value == self.minimum_value:
+            return 999
+        return float( -p_value.log10() )
+

--- a/test/test_vcf.py
+++ b/test/test_vcf.py
@@ -1,14 +1,16 @@
 from vcf import Vcf
 import numpy as np
 import pickle
+import decimal
 from gwas import Gwas
 import tempfile
 from heapq import heappush, heappop
-
+from pvalueHandler import PvalueHandler
 
 def test_convert_pval_to_neg_log10():
-    assert Vcf.convert_pval_to_neg_log10(1) == 0
-    assert Vcf.convert_pval_to_neg_log10(0) == 999
+    p_value_handler = PvalueHandler()
+    assert p_value_handler.neg_log_of_decimal(decimal.Decimal(1)) == 0
+    assert p_value_handler.neg_log_of_decimal(decimal.Decimal(0)) == 999
 
 
 def test_is_valid_float32():
@@ -27,9 +29,14 @@ def test_is_valid_float32():
 
 
 def test_gwas_unpickle():
+    p_value_handler = PvalueHandler()
+    precision_check = {"string":"1E-10000","nlog_value":10000}
     g1 = [Gwas("1", 101, "A", "T", 1, 0, 5e-8, 1000, 0.4, "rs1234", None, None, None),
           Gwas("1", 105, "A", "T", 1, 0, 5e-8, 1000, 0.4, "rs1234", None, None, None),
-          Gwas("1", 102, "A", "T", 1, 0, 5e-8, 1000, 0.4, "rs1234", None, None, None)]
+          Gwas("1", 102, "A", "T", 1, 0, 5e-8, 1000, 0.4, "rs1234", None, None, None),
+          Gwas("1", 103, "A", "T", 1, 0, p_value_handler.neg_log_of_decimal(p_value_handler.parse_string(precision_check ["string"])),
+               1000, 0.4, "rs1234", None, None, None)
+          ]
     g2 = []
     idx = []
     results = tempfile.TemporaryFile()
@@ -43,8 +50,12 @@ def test_gwas_unpickle():
         result = pickle.load(results)
         g2.append(result)
 
+    epsilon = g2[2].nlog_pval/1000000.0
     assert g2[0].pos == 101
     assert g2[1].pos == 102
-    assert g2[2].pos == 105
+    assert g2[2].pos == 103
+    assert g2[2].nlog_pval > precision_check ["nlog_value"]- epsilon
+    assert g2[2].nlog_pval < precision_check ["nlog_value"]+epsilon
+    assert g2[3].pos == 105
 
     results.close()

--- a/vcf.py
+++ b/vcf.py
@@ -4,18 +4,18 @@ import numpy as np
 import pickle
 from heapq import heappop
 
-
 class Vcf:
 
-    @staticmethod
-    def convert_pval_to_neg_log10(p):
-        # prevent negative 0 output
-        if p == 1:
-            return 0
-        # prevent Inf output
-        if p == 0:
-            return 999
-        return -np.log10(p)
+    # no longer necessary
+    # @staticmethod
+    # def convert_pval_to_neg_log10(p):
+    #     # prevent negative 0 output
+    #     if p == 1:
+    #         return 0
+    #     # prevent Inf output
+    #     if p == 0:
+    #         return 999
+    #     return -np.log10(p)
 
     @staticmethod
     def is_float32_lossy(f):
@@ -122,7 +122,7 @@ class Vcf:
                 gwas_file.seek(chr_pos[1])
                 result = pickle.load(gwas_file)
 
-                lpval = Vcf.convert_pval_to_neg_log10(result.pval)
+                result.nlog_pval = result.nlog_pval
 
                 # check floats
                 if Vcf.is_float32_lossy(result.b):
@@ -136,10 +136,10 @@ class Vcf:
                         "Standard error field cannot fit into float32. Expect loss of precision for: {}".format(
                             result.se)
                     )
-                if Vcf.is_float32_lossy(lpval):
+                if Vcf.is_float32_lossy(result.nlog_pval):
                     logging.warning(
                         "-log10(pval) field cannot fit into float32. Expect loss of precision for: {}".format(
-                            lpval)
+                            result.nlog_pval)
                     )
                 if Vcf.is_float32_lossy(result.alt_freq):
                     logging.warning(
@@ -173,8 +173,8 @@ class Vcf:
                     record.samples[trait_id]['ES'] = result.b
                 if result.se is not None:
                     record.samples[trait_id]['SE'] = result.se
-                if lpval is not None:
-                    record.samples[trait_id]['LP'] = lpval
+                if result.nlog_pval is not None:
+                    record.samples[trait_id]['LP'] = result.nlog_pval
                 if result.alt_freq is not None:
                     record.samples[trait_id]['AF'] = result.alt_freq
                 if result.n is not None:


### PR DESCRIPTION
Hello Matthew and Gibran,

I am a big fan of gwas2vcf.  Your idea of using vgraph as a principled approach to identifying variants and then mapping everything straight to the human reference is great, and far better than the string matching used by the EBI program (https://github.com/EBISPOT/gwas-sumstats-harmoniser).  In fact, I have only one suggested improvement for your program, which is to change the handling for extremely small p-values.  As you know, 8 byte floating point numbers can't get much smaller than 10e-308, and unfortunately there are more and more GWAS referencing p-values far smaller than that.  Therefore I added a class to your code which treats P values as decimals, and now small P values are handled without rounding them to zero.  I tried to change youe code as little as possible, but the one big change was to make your Gwas class hold the negative log  of the p-value,  since that seemed like the most reliable way to get everything to pickle correctly.

So that's it.  I hope this change seems well motivated, and if so that you will incorporate it going forward ( or else provide a different implementation that achieves the same end).  I am proposing your harmonizer as a crucial part of the GWAS processing for the genetics community here at Pfizer, and I want to make sure that the results will keep all of our scientists happy.

Thanks for your efforts and your excellent work!
Ben

Ben Alexander
Simulations and Modeling Sciences Dept.
Pfizer, Cambridge Massachusetts
Benjamin.Alexander@pfizer.com