### PR TITLE
Qualify name for Docker example in docs

### DIFF
--- a/mkdocs/install.md
+++ b/mkdocs/install.md
@@ -47,7 +47,7 @@ Run
 docker run \
 -v /path/to/fasta:/path/to/fasta \
 --name gwas2vcf \
--it gwas2vcf:latest \
+-it mrcieu/gwas2vcf:latest \
 python main.py -h
 ```
 


### PR DESCRIPTION
I got an error trying to run the pulled image, and when I added the repo owner to the image name it worked in the Docker example from the docs.